### PR TITLE
Migration des identifiants externes dans le modèle des agences (Immodvisor x Sergic)

### DIFF
--- a/src/components/schemas/Agency.yaml
+++ b/src/components/schemas/Agency.yaml
@@ -3,8 +3,11 @@ properties:
   id:
     type: integer
     format: int64
-  externalId:
-    type: string
+  externalIds:
+    type: object
+    properties:
+      CLIENT:
+        type: string
   organizationId:
     type: integer
     format: int64


### PR DESCRIPTION
- le champ `externalId` du modèle `Agency` est déplacé dans `externalIds` avec la clé `CLIENT`.